### PR TITLE
[Collections] Customize UIEdgeInsets in MDCCVC

### DIFF
--- a/components/CollectionCells/examples/CollectionCellsTextExample.m
+++ b/components/CollectionCells/examples/CollectionCellsTextExample.m
@@ -43,6 +43,7 @@ static NSString *const kExampleDetailText =
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+  self.styler.cellStyle = MDCCollectionViewCellStyleCard;
 
   // Register cell class.
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]
@@ -88,6 +89,15 @@ static NSString *const kExampleDetailText =
 - (CGFloat)collectionView:(UICollectionView *)collectionView
     cellHeightAtIndexPath:(NSIndexPath *)indexPath {
   return [_content[indexPath.item][2] integerValue];
+}
+
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
+  UIEdgeInsets insets = [super collectionView:collectionView layout:collectionViewLayout insetForSectionAtIndex:section];
+  if ([self.styler cellStyleAtSectionIndex:section] == MDCCollectionViewCellStyleCard && self.view.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+    insets.left *= 2;
+    insets.right *= 2;
+  }
+  return insets;
 }
 
 @end

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -213,7 +213,7 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 - (CGFloat)cellWidthAtSectionIndex:(NSInteger)section {
   CGFloat bounds = CGRectGetWidth(
       UIEdgeInsetsInsetRect(self.collectionView.bounds, self.collectionView.contentInset));
-  UIEdgeInsets sectionInsets = [self insetsAtSectionIndex:section];
+  UIEdgeInsets sectionInsets = [self collectionView:self.collectionView layout:self.collectionView.collectionViewLayout insetForSectionAtIndex:section]; //[self insetsAtSectionIndex:section];
   CGFloat insets = sectionInsets.left + sectionInsets.right;
   if (_styler.cellLayoutType == MDCCollectionViewCellLayoutTypeGrid) {
     CGFloat cellWidth = bounds - insets - (_styler.gridPadding * (_styler.gridColumnCount - 1));

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -389,9 +389,15 @@ static const NSInteger kSupplementaryViewZIndex = 99;
   // value. The opposite is true for horizontal scrolling. Therefore we must manually set insets
   // on both the backgroundView and contentView in order to match the insets of the collection
   // view rows.
+  id<UICollectionViewDelegateFlowLayout> flowLayoutDelegate = (id<UICollectionViewDelegateFlowLayout>)self.collectionView.delegate;
+  UIEdgeInsets insets = self.sectionInset;
+  if ([flowLayoutDelegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)]) {
+    insets = [flowLayoutDelegate collectionView:self.collectionView layout:self insetForSectionAtIndex:attr.indexPath.section];
+  }
+
   CGRect insetFrame = attr.frame;
   if (!CGRectIsEmpty(insetFrame)) {
-    UIEdgeInsets insets = [self insetsAtSectionIndex:attr.indexPath.section];
+    insets = [self insetsAtSectionIndex:attr.indexPath.section];
     if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
       insetFrame = CGRectInset(insetFrame, insets.left / 2 + insets.right / 2, 0);
       if ([attr.representedElementKind isEqualToString:UICollectionElementKindSectionHeader]) {

--- a/components/Collections/src/MDCCollectionViewFlowLayout.m
+++ b/components/Collections/src/MDCCollectionViewFlowLayout.m
@@ -389,15 +389,16 @@ static const NSInteger kSupplementaryViewZIndex = 99;
   // value. The opposite is true for horizontal scrolling. Therefore we must manually set insets
   // on both the backgroundView and contentView in order to match the insets of the collection
   // view rows.
-  id<UICollectionViewDelegateFlowLayout> flowLayoutDelegate = (id<UICollectionViewDelegateFlowLayout>)self.collectionView.delegate;
-  UIEdgeInsets insets = self.sectionInset;
-  if ([flowLayoutDelegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)]) {
-    insets = [flowLayoutDelegate collectionView:self.collectionView layout:self insetForSectionAtIndex:attr.indexPath.section];
-  }
-
-  CGRect insetFrame = attr.frame;
+    CGRect insetFrame = attr.frame;
   if (!CGRectIsEmpty(insetFrame)) {
-    insets = [self insetsAtSectionIndex:attr.indexPath.section];
+    id<UICollectionViewDelegateFlowLayout> flowLayoutDelegate = (id<UICollectionViewDelegateFlowLayout>)self.collectionView.delegate;
+    UIEdgeInsets insets = self.sectionInset;
+    if ([flowLayoutDelegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)]) {
+      insets = [flowLayoutDelegate collectionView:self.collectionView layout:self insetForSectionAtIndex:attr.indexPath.section];
+    }
+    else {
+      insets = [self insetsAtSectionIndex:attr.indexPath.section];
+    }
     if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
       insetFrame = CGRectInset(insetFrame, insets.left / 2 + insets.right / 2, 0);
       if ([attr.representedElementKind isEqualToString:UICollectionElementKindSectionHeader]) {

--- a/demos/Pesto/Pesto/PestoSettingsViewController.m
+++ b/demos/Pesto/Pesto/PestoSettingsViewController.m
@@ -62,8 +62,6 @@ static NSString *const kReusableIdentifierItem = @"itemCellIdentifier";
   backButton.image = backImage;
   self.navigationItem.leftBarButtonItem = backButton;
   self.navigationItem.rightBarButtonItem = nil;
-  [self.collectionView registerClass:[MDCCollectionViewTextCell class]
-          forCellWithReuseIdentifier:kReusableIdentifierItem];
 
   // Register cell.
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]


### PR DESCRIPTION
Proof-of-concept code to allow customized UIEdgeInset values for different layouts/cell types.

* MDCCollectionViewController will call the UIViewControllerFlowLayoutDelegate method directly when computing cell widths (instead of calling the internal implementation)
* MDCCollectionViewFlowLayout will check to see if the collectionView has a delegate to retrieve the insets first, then fall-back to the internal behavior.